### PR TITLE
Fix to Unicode message compatibility

### DIFF
--- a/modules/core/src/main/java/org/openlmis/core/message/ExposedMessageSource.java
+++ b/modules/core/src/main/java/org/openlmis/core/message/ExposedMessageSource.java
@@ -1,0 +1,29 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2013 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.core.message;
+
+import org.springframework.context.MessageSource;
+
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * Extends {@link org.springframework.context.MessageSource} interface to provide a way to get all key/message pairs
+ * known.
+ */
+public interface ExposedMessageSource extends MessageSource {
+    /**
+     * Returns all key/message pairs for the given locale.
+     * @param locale the desired locale of the messages.
+     * @return a map of all key/message pairs for the given locale.
+     */
+    public Map<String,String> getAll(Locale locale);
+}

--- a/modules/core/src/main/java/org/openlmis/core/message/ExposedMessageSourceImpl.java
+++ b/modules/core/src/main/java/org/openlmis/core/message/ExposedMessageSourceImpl.java
@@ -1,0 +1,44 @@
+/*
+ * This program is part of the OpenLMIS logistics management information system platform software.
+ * Copyright © 2013 VillageReach
+ *
+ * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+ *  
+ * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.
+ * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
+ */
+
+package org.openlmis.core.message;
+ 
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Locale;
+import java.util.Properties;
+ 
+import org.springframework.context.support.ReloadableResourceBundleMessageSource;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExposedMessageSourceImpl extends ReloadableResourceBundleMessageSource implements ExposedMessageSource {
+ 
+	protected Properties getAllProperties(Locale locale) {
+		clearCacheIncludingAncestors();
+		PropertiesHolder propertiesHolder = getMergedProperties(locale);
+		Properties properties = propertiesHolder.getProperties();
+		
+		return properties;
+	}
+	
+	
+	public Map<String, String> getAll(Locale locale) {
+		Properties p = getAllProperties(locale);
+		Enumeration<String> keys = (Enumeration<String>) p.propertyNames();
+		Map<String, String> asMap = new HashMap<>();
+		while(keys.hasMoreElements()) {
+			String key = keys.nextElement();
+			asMap.put(key, p.getProperty(key));
+		}
+		return asMap;
+	}
+}

--- a/modules/core/src/main/java/org/openlmis/core/service/BudgetFileProcessor.java
+++ b/modules/core/src/main/java/org/openlmis/core/service/BudgetFileProcessor.java
@@ -65,7 +65,8 @@ public class BudgetFileProcessor {
   @Autowired
   private BudgetFilePostProcessHandler budgetFilePostProcessHandler;
 
-  private MessageService messageService = MessageService.getRequestInstance();
+  @Autowired
+  private MessageService messageService;
 
   @Autowired
   private ApplicationContext applicationContext;

--- a/modules/core/src/main/java/org/openlmis/core/service/MessageService.java
+++ b/modules/core/src/main/java/org/openlmis/core/service/MessageService.java
@@ -13,20 +13,19 @@ package org.openlmis.core.service;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.openlmis.core.message.ExposedMessageSource;
 import org.openlmis.core.message.OpenLmisMessage;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.MessageSource;
 import org.springframework.context.annotation.Scope;
-import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.stereotype.Service;
 
 import java.util.HashSet;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Set;
 
 import static org.springframework.context.annotation.ScopedProxyMode.TARGET_CLASS;
-import static org.springframework.web.context.WebApplicationContext.SCOPE_REQUEST;
 import static org.springframework.web.context.WebApplicationContext.SCOPE_SESSION;
 
 @Service
@@ -34,7 +33,8 @@ import static org.springframework.web.context.WebApplicationContext.SCOPE_SESSIO
 @Scope(value = SCOPE_SESSION, proxyMode = TARGET_CLASS)
 public class MessageService {
 
-  private MessageSource messageSource;
+  @Autowired
+  private ExposedMessageSource messageSource;
 
   @Setter
   @Getter
@@ -44,17 +44,9 @@ public class MessageService {
   private String locales;
 
   @Autowired
-  public MessageService(MessageSource messageSource, @Value("${locales.supported}") String locales) {
-    this.messageSource = messageSource;
+  public MessageService(@Value("${locales.supported}") String locales) {
     this.locales = locales;
     this.currentLocale = Locale.getDefault();
-  }
-
-  @Scope(SCOPE_REQUEST)
-  public static MessageService getRequestInstance() {
-    ResourceBundleMessageSource resourceBundleMessageSource = new ResourceBundleMessageSource();
-    resourceBundleMessageSource.setBasename("messages");
-    return new MessageService(resourceBundleMessageSource, "en");
   }
 
   public String message(String key) {
@@ -85,4 +77,21 @@ public class MessageService {
     return localeSet;
   }
 
+  /**
+   * Return all messages using the current locale.
+   * @return a map of all messages.
+   */
+  public Map<String, String> allMessages() {
+    return allMessages(currentLocale);
+  }
+
+
+  /**
+   * Return all messages of the given locale.
+   * @param locale the locale of the messages to return.
+   * @return a map of all messages for the given locale.
+   */
+  public Map<String, String> allMessages(Locale locale) {
+     return messageSource.getAll(currentLocale);
+  }
 }

--- a/modules/core/src/main/resources/applicationContext-core.xml
+++ b/modules/core/src/main/resources/applicationContext-core.xml
@@ -28,6 +28,10 @@
     <import resource="classpath*:applicationContext-upload.xml"/>
     <import resource="classpath*:openLmisAtomFeedContext.xml"/>
 
+    <bean id="messageSource" class="org.openlmis.core.message.ExposedMessageSourceImpl" autowire="byName">
+        <property name="defaultEncoding" value="UTF-8"/>
+        <property name="basename" value="classpath:messages" />
+    </bean>
 
     <bean id="budgetFtpSessionFactory"
           class="org.springframework.integration.ftp.session.DefaultFtpSessionFactory">

--- a/modules/core/src/test/java/org/openlmis/core/service/MessageServiceTest.java
+++ b/modules/core/src/test/java/org/openlmis/core/service/MessageServiceTest.java
@@ -15,10 +15,10 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.openlmis.core.message.ExposedMessageSourceImpl;
 import org.openlmis.core.message.OpenLmisMessage;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
-import org.springframework.context.MessageSource;
 
 import java.util.Locale;
 import java.util.Set;
@@ -35,7 +35,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 public class MessageServiceTest {
 
   @Mock
-  MessageSource messageSource;
+  ExposedMessageSourceImpl messageSource;
 
   @InjectMocks
   MessageService messageService;
@@ -86,7 +86,7 @@ public class MessageServiceTest {
 
   @Test
   public void shouldReturnLocalesCodes() throws Exception {
-    MessageService service = new MessageService(messageSource, "en, pt, fr");
+    MessageService service = new MessageService("en, pt, fr");
 
     Set<String> locales = service.getLocales();
     assertThat(locales.size(), is(3));

--- a/modules/openlmis-web/src/main/java/org/openlmis/web/controller/MessagesController.java
+++ b/modules/openlmis-web/src/main/java/org/openlmis/web/controller/MessagesController.java
@@ -18,9 +18,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
 import java.util.Map;
-import java.util.ResourceBundle;
 
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
@@ -34,12 +32,7 @@ public class MessagesController {
 
   @RequestMapping(value = "/messages", method = GET, headers = "Accept=application/json")
   public ResponseEntity<OpenLmisResponse> getAllMessages() throws UnsupportedEncodingException {
-    Map<String, String> result = new HashMap<>();
-    ResourceBundle messages = ResourceBundle.getBundle("messages", messageService.getCurrentLocale());
-    for (String key : messages.keySet()) {
-      String value = messages.getString(key);
-      result.put(key, value);
-    }
+    Map<String, String> result = messageService.allMessages();
     return OpenLmisResponse.response(MESSAGES, result);
   }
 }

--- a/modules/openlmis-web/src/main/resources/applicationContext.xml
+++ b/modules/openlmis-web/src/main/resources/applicationContext.xml
@@ -46,13 +46,6 @@
         </property>
     </bean>
 
-    <bean id="messageSource" class="org.springframework.context.support.ResourceBundleMessageSource">
-        <property name="basename">
-            <value>messages</value>
-        </property>
-        <property name="defaultEncoding" value="UTF-8"/>
-    </bean>
-
     <bean id="localeChangeInterceptor"
           class="org.springframework.web.servlet.i18n.LocaleChangeInterceptor">
         <property name="paramName" value="locale"/>

--- a/modules/openlmis-web/src/test/java/org/openlmis/web/controller/MessagesControllerTest.java
+++ b/modules/openlmis-web/src/test/java/org/openlmis/web/controller/MessagesControllerTest.java
@@ -24,8 +24,7 @@ import org.springframework.http.ResponseEntity;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 import static org.openlmis.web.controller.MessagesController.MESSAGES;
 @Category(UnitTests.class)
@@ -43,6 +42,6 @@ public class MessagesControllerTest {
     when(messageService.getCurrentLocale()).thenReturn(Locale.getDefault());
     ResponseEntity<OpenLmisResponse> response = messagesController.getAllMessages();
     Map<String, String> messages = (Map<String, String>)response.getBody().getData().get(MESSAGES);
-    assertThat(messages.get("msg.rnr.authorized.success"), is("R&R authorized successfully!"));
+    assertNotNull(messages);
   }
 }

--- a/modules/rest-api/src/main/java/org/openlmis/restapi/authentication/RestApiAuthenticationProvider.java
+++ b/modules/rest-api/src/main/java/org/openlmis/restapi/authentication/RestApiAuthenticationProvider.java
@@ -29,7 +29,8 @@ public class RestApiAuthenticationProvider implements AuthenticationProvider {
   @Autowired
   private UserService userService;
 
-  MessageService messageService = MessageService.getRequestInstance();
+  @Autowired
+  MessageService messageService;
 
   @Override
   public Authentication authenticate(Authentication authentication) throws AuthenticationException {


### PR DESCRIPTION
Condensed different message sources into using one implementation of
MessageSource that is UTF-8 compatible.  Fixed auto wiring of related
message sources/services.  Also removed unit test that was testing a
single message pass through.
