### PR TITLE
Fixed app title on login screen

### DIFF
--- a/modules/openlmis-web/src/main/webapp/public/pages/login.html
+++ b/modules/openlmis-web/src/main/webapp/public/pages/login.html
@@ -9,11 +9,11 @@
   ~ You should have received a copy of the GNU Affero General Public License along with this program.  If not, see http://www.gnu.org/licenses.  For additional information contact info@OpenLMIS.org. 
   -->
 
-<html xmlns="http://www.w3.org/1999/html">
+<html lang="en" ng-app="openlmis" xmlns="http://www.w3.org/1999/html">
 <head>
   <meta content="text/html;charset=utf-8" http-equiv="Content-Type">
   <meta content="utf-8" http-equiv="encoding">
-  <title openlmis-message="app.title">Open-LMIS</title>
+  <title openlmis-message="app.title"></title>
   <link rel="icon" href="/public/favicon.ico" type="image/x-icon"/>
   <script src="/public/lib/jquery/jquery-2.0.0.min.js"></script>
   <script src="/public/lib/angular/angular.min.js"></script>


### PR DESCRIPTION
App title was always showing as Open-LMIS on login screen, fixed so
that it uses the message defined
