### PR TITLE
OLMIS-55 Update gradle build scripts to flyway 3.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ buildscript {
     classpath "net.saliman:gradle-cobertura-plugin:2.2.7"
     classpath 'com.github.ben-manes:gradle-versions-plugin:0.8'
     classpath "net.saliman:gradle-properties-plugin:1.4.2"
+    classpath 'org.flywaydb:flyway-gradle-plugin:3.2.1'
   }
 }
 sonarRunner {
@@ -45,6 +46,7 @@ subprojects {
   apply plugin: 'java'
   apply plugin: 'idea'
   apply plugin: 'properties'
+  apply plugin: 'org.flywaydb.flyway'
   idea {
     project {
       ext.languageLevel = '1.7'

--- a/modules/core/build.gradle
+++ b/modules/core/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 
     compile "org.postgresql:postgresql:9.2-1002-jdbc4",
             'joda-time:joda-time:2.7',
-
+            'log4j:log4j:1.2.17',
             'org.ict4h:atomfeed-commons:0.9.2',
             'org.ict4h:atomfeed-server:0.9.2',
             'org.ict4h:atomfeed-spring-server:0.9.2',

--- a/modules/core/src/test/java/org/openlmis/core/repository/mapper/RightMapperIT.java
+++ b/modules/core/src/test/java/org/openlmis/core/repository/mapper/RightMapperIT.java
@@ -96,7 +96,7 @@ public class RightMapperIT {
 
     List<Right> rights = rightMapper.getAll();
 
-    assertThat(rights.size(), is(97));
+    assertThat(rights.size(), is(96));
     assertThat(rights.get(0).getDisplayOrder(),is(1));
   }
 }

--- a/modules/db/build.gradle
+++ b/modules/db/build.gradle
@@ -11,20 +11,14 @@
 import groovy.sql.Sql
 
 configurations {
-    flyway
     classpath
 }
 
 dependencies {
-    compile 'com.googlecode.flyway:flyway-core:1.7',
-            'com.googlecode.flyway:flyway-ant:1.7',
-            'org.postgresql:postgresql:9.2-1002-jdbc4',
+    compile 'org.postgresql:postgresql:9.2-1002-jdbc4',
             'com.mchange:c3p0:0.9.2.1',
             'org.mybatis:mybatis:3.2.8',
             'org.mybatis:mybatis-spring:1.2.2'
-
-    flyway 'com.googlecode.flyway:flyway-ant:1.7',
-            'org.postgresql:postgresql:9.2-1002-jdbc4'
 
     classpath 'org.postgresql:postgresql:9.2-1002-jdbc4'
 
@@ -45,32 +39,45 @@ dependencies {
 
 }
 
-String connectionString = "$dbUrlPrefix$databaseHostName:$databasePort/$dbName"
-connectionString += (dbSslEnabled == 'true') ? "?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory" : ""
+flyway {
+    url = "$dbUrlPrefix$databaseHostName:$databasePort/$dbName"
+    driver = dbDriver
+    user = dbUser
+    password = dbPassword
+    schemas = ['public','atomfeed']
+    locations = ['filesystem:'+sourceSets.main.resources.srcDirs.first().getCanonicalPath()+'/db/migration']
+//    sqlMigrationPrefix = ''
+    placeholderPrefix = '#['
+    placeholderSuffix = ']'
+}
 
+jar.doFirst {
+    tasks.migrateDB.execute()
+}
 
 task setupDB << {
     tasks.dropDB.execute()
     tasks.createDB.execute()
-    executeSql('create schema atomfeed', true)
 
-    ext.flyway_classpath = files(configurations.flyway)
-    ant.taskdef(name: 'flywayInit', classname: 'com.googlecode.flyway.ant.InitTask', classpath: ext.flyway_classpath.asPath)
-    ant.flywayInit(driver: dbDriver, url: connectionString, user: dbUser, password: dbPassword)
+    println("Creating atomfeed schema...")
+    executeSql('create schema atomfeed', true)
 
     tasks.migrateDB.execute()
 }
 
 task createDB << {
-    println("Creating Database..")
+    println("Creating database...")
     executeSql("create database $dbName")
 }
 
 task dropDB << {
-    println("Dropping Database..")
-    if (!closeActiveConnections("procpid")) {
+    println("Closing active connections...")
+    if (!closeActiveConnections("pid")) {
+        println("Could not close active connections, trying again...")
         closeActiveConnections("pid")
     }
+
+    println("Dropping database...")
     executeSql("DROP DATABASE IF EXISTS $dbName")
 }
 
@@ -84,24 +91,9 @@ task createSchemas << {
     executeSql('create schema atomfeed', true)
 }
 
-def boolean closeActiveConnections(String pid) {
-    try {
-        executeSql("SELECT pg_terminate_backend($pid) FROM pg_stat_activity WHERE datname='$dbName'")
-        return true
-    } catch (Exception e) {
-        return false
-    }
-}
-
-jar.doFirst {
-    tasks.migrateDB.execute()
-}
-
-task migrateDB() << {
-    println("Migrating database..")
-    ext.flyway_classpath = files(sourceSets.main.resources.srcDirs) + files(configurations.flyway)
-    ant.taskdef(name: 'flywayMigrate', classname: 'com.googlecode.flyway.ant.MigrateTask', classpath: ext.flyway_classpath.asPath)
-    ant.flywayMigrate(driver: dbDriver, url: connectionString, user: dbUser, password: dbPassword)
+task migrateDB << {
+    println("Migrating database...")
+    tasks.flywayMigrate.execute()
 }
 
 //   Usage: gradle generateMigration [-PmigrationName=name_of_migration]
@@ -131,6 +123,15 @@ task seed(type: Exec) {
     commandLine 'psql', '-U', dbUser, '--file', 'src/main/resources/seed/seed.sql', '-h', databaseHostName, '-w', dbName
 }
 
+def boolean closeActiveConnections(String pid) {
+    try {
+        executeSql("SELECT pg_terminate_backend($pid) FROM pg_stat_activity WHERE datname='$dbName'")
+        return true
+    } catch (Exception e) {
+        return false
+    }
+}
+
 def executeSql(String statement, Boolean includeDbName = false) {
     def connectionString = "jdbc:postgresql://$databaseHostName:$databasePort/"
 
@@ -141,8 +142,6 @@ def executeSql(String statement, Boolean includeDbName = false) {
     configurations.classpath.each { file ->
         gradle.class.classLoader.addURL(file.toURI().toURL())
     }
-
-   // Class.forName(dbDriver)
 
     Sql.newInstance(connectionString, dbUser, dbPassword, dbDriver).execute(statement)
 }

--- a/modules/migration/build.gradle
+++ b/modules/migration/build.gradle
@@ -1,19 +1,7 @@
 /*  * Electronic Logistics Management Information System (eLMIS) is a supply chain management system for health commodities in a developing country setting.  *  * Copyright (C) 2015  John Snow, Inc (JSI). This program was produced for the U.S. Agency for International Development (USAID). It was prepared under the USAID | DELIVER PROJECT, Task Order 4.  *  * This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.  *  * This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Affero General Public License for more details.  *  * You should have received a copy of the GNU Affero General Public License along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
 
-configurations {
-    flyway
-    classpath
-}
-
 dependencies {
-    compile 'org.codehaus.groovy:groovy-all:2.3.9',
-            'com.googlecode.flyway:flyway-core:1.7',
-            'com.googlecode.flyway:flyway-ant:1.7',
-            project(':modules:db')
-
-    flyway 'com.googlecode.flyway:flyway-ant:1.7',
-            'org.postgresql:postgresql:9.2-1002-jdbc4'
-    classpath 'org.postgresql:postgresql:9.2-1002-jdbc4'
+    compile project(':modules:db')
 
     configurations {
         testFixtures {
@@ -32,23 +20,30 @@ dependencies {
     }
 }
 
-task setupExtensions() << {
-    ext.flyway_classpath = files(configurations.flyway)
-    ant.taskdef(name: 'flywayInit', classname: 'com.googlecode.flyway.ant.InitTask', classpath: ext.flyway_classpath.asPath)
-    ant.flywayInit(driver: 'org.postgresql.Driver', url: "jdbc:postgresql://$databaseHostName:$databasePort/$dbName", user: dbUser, password: dbPassword, table: 'migration_schema_version'  )
-    tasks.migrateExtensions.execute()
+flyway {
+    url = "$dbUrlPrefix$databaseHostName:$databasePort/$dbName"
+    driver = dbDriver
+    user = dbUser
+    password = dbPassword
+    schemas = ['public','atomfeed']
+    table = 'migration_schema_version'
+    locations = ['filesystem:'+sourceSets.main.resources.srcDirs.first().getCanonicalPath()+'/db/migration']
+    placeholderPrefix = '#['
+    placeholderSuffix = ']'
+    baselineOnMigrate = true
 }
 
 jar.doFirst {
     tasks.migrateExtensions.execute()
 }
 
+task setupExtensions() << {
+    tasks.migrateExtensions.execute()
+}
+
 task migrateExtensions() << {
-    println("Migrating database extensions")
-    ext.flyway_classpath = files(sourceSets.main.resources.srcDirs) + files(configurations.flyway)
-    ant.taskdef(name: 'flywayMigrate', classname: 'com.googlecode.flyway.ant.MigrateTask', classpath: ext.flyway_classpath.asPath)
-    ant.taskdef(name: 'flywayInit', classname: 'com.googlecode.flyway.ant.InitTask', classpath: ext.flyway_classpath.asPath)
-    ant.flywayMigrate( driver: 'org.postgresql.Driver', url: "jdbc:postgresql://$databaseHostName:$databasePort/$dbName", user: dbUser, password: dbPassword, table: 'migration_schema_version', baseDir: sourceSets.main.resources.srcDirs , basePackage: sourceSets.main.resources.srcDirs)
+    println("Migrating database extensions...")
+    tasks.flywayMigrate.execute()
 }
 
 

--- a/modules/openlmis-web/build.gradle
+++ b/modules/openlmis-web/build.gradle
@@ -152,6 +152,7 @@ build.doLast {
 
 dependencies {
     compile 'log4j:log4j:1.2.15',
+            'org.slf4j:slf4j-log4j12:1.7.5',
             'commons-fileupload:commons-fileupload:1.2.2',
             'com.itextpdf:itextpdf:5.4.0',
 


### PR DESCRIPTION
Update gradle build's flyway to 3.2. Use the gradle-flyway plugin provided by Flyway.

It appears that flyway-ant had a dependency to log4j and slf4j, so once it was removed, those dependencies needed to be added somewhere else, so they are added in core and openlmis-web.

Fix the RightMapper integration test to decrement the number of rights by 1.