### PR TITLE
Fix OutOfMemoryError when running gradle build jetty server

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,7 @@ See [SonarQube.org](http://www.sonarqube.org/) for official documentation.  For 
   [OpenLMIS sonar-configuration](https://github.com/OpenLMIS/sonar-configuration) repository.
 
 ## Issues
-1. You may encounter a `java.lang.OutOfMemoryError: PermGen space`. This is a result of not enough memory for the Jetty JVM. One way to fix this is to export the following (or include in `$HOME/.bash_profile` or `$HOME/.profile` or `$HOME/.bashrc` or `$HOME/.zshrc`, depending on your shell).
-
-    ```bash
-    export JAVA_OPTS="-XX:MaxPermSize=512m"
-    export JAVA_TOOL_OPTIONS="-Xmx1024m -XX:MaxPermSize=512m -Xms512m"
-    ```
-2. If a few integration tests fail, like this:
+1. If a few integration tests fail, like this:
 `org.openlmis.core.repository.mapper.FacilityMapperIT > shouldUpdateFacilityWithSuppliedModifiedTime FAILED java.lang.AssertionError at FacilityMapperIT.java:292`
 This can be caused by the timezone in `postgresql.conf` being different than your operating system timezone. To fix, stop the postgresql server, and edit the following line: `timezone = 'US/Pacific'` to match your current operating system timezone, then restart the postgresql server.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ atomfeedDbSchema = atomfeed
 baseurl = http://localhost:9091/
 httpport = 9091
 
-#org.gradle.jvmargs=-Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=8877
+org.gradle.jvmargs=-Xmx1024m -XX:MaxPermSize=512m -Xms512m
 
 sonarServer = http://localhost:9000
 sonarJdbc = jdbc:h2:tcp://localhost/sonar


### PR DESCRIPTION
There is an old OutOfMemoryError issue when running jetty in the gradle build. This is because of not enough memory for Jetty. The workaround has been to have the builder export JAVA_OPTS and JAVA_TOOL_OPTIONS to up the memory. We can fix this by setting a gradle property to up the memory when running gradle.