### PR TITLE
OLMIS-132 Fix bugs in create/edit equipment page

### DIFF
--- a/modules/openlmis-web/src/main/webapp/public/js/admin/equipment/manage/controller/create-equipment-controller.js
+++ b/modules/openlmis-web/src/main/webapp/public/js/admin/equipment/manage/controller/create-equipment-controller.js
@@ -81,7 +81,6 @@ function CreateEquipmentController($scope, $routeParams, $location, Equipment,Eq
       }
       else{
         $scope.equipment.equipmentTypeName = "equipment";
-        $scope.equipment.designationId=$scope.equipment.designation.id;
       }
       SaveEquipment.save($scope.equipment, onSuccess, onError);
     }

--- a/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/manage/partials/create.html
+++ b/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/manage/partials/create.html
@@ -30,48 +30,18 @@
     <div ng-show="equipment.equipmentType.coldChain != undefined ">
       <div class="form-row clearfix" >
 
-
-        <div class="form-cell" >
-          <label for="designation">
-            <span openlmis-message="label.equipment.designation"></span>
-            <span class="label-required">*</span>
-          </label>
-          <div class="form-field">
-            <select ng-model="equipment.designation" ng-options="designation as designation.name for designation in designations" id="designation" name="designation" ng-required="equipment.equipmentType.coldChain">
-              <option openlmis-mesage="Select"  value=""></option>
-            </select>
-            <span class="field-error" ng-show="equipmentForm.designation.$error.required && showError" openlmis-message="missing.value"></span>
-          </div>
-        </div>
-
-         <div class="form-cell">
+        <div class="form-cell">
           <label for="name">
             <span openlmis-message="label.equipment.name"></span>
             <span class="label-required">*</span>
           </label>
-
           <div class="form-field">
             <input ng-readonly="equipment.equipmentType.coldChain" ng-model="equipment.name" id="name" type="text" maxlength="200" ng-required="true" />
             <span class="field-error" ng-show="equipmentForm.name.$error.required && showError" openlmis-message="missing.value"></span>
           </div>
         </div>
-      </div>
 
-      <div class="form-row clearfix">
-
-        <div class="form-cell" ng-show="equipment.designation !==undefined">
-          <label for="model">
-            <span openlmis-message="label.equipment.model"></span>
-            <span class="label-required">*</span>
-          </label>
-
-          <div class="form-field">
-            <input ng-model="equipment.model" name="model" ng-change="updateName(equipment.equipmentType.coldChain)" id="model" type="text" maxlength="200" ng-required="true" />
-            <span class="field-error" ng-show="equipmentForm.model.$error.required && showError" openlmis-message="missing.value"></span>
-          </div>
-        </div>
-
-        <div class="form-cell" ng-show="equipment.designation !==undefined">
+        <div class="form-cell">
           <label for="manufacturer">
             <span openlmis-message="label.equipment.manufacturer"></span>
             <span class="label-required">*</span>
@@ -81,13 +51,26 @@
             <span class="field-error" ng-show="equipmentForm.manufacturer.$error.required && showError" openlmis-message="missing.value"></span>
           </div>
         </div>
+
       </div>
 
       <div class="form-row clearfix">
-        <div class="form-cell" ng-show="equipment.designation !==undefined && equipment.designation.hasEnergy">
+
+        <div class="form-cell">
+          <label for="model">
+            <span openlmis-message="label.equipment.model"></span>
+            <span class="label-required">*</span>
+          </label>
+          <div class="form-field">
+            <input ng-model="equipment.model" name="model" ng-change="updateName(equipment.equipmentType.coldChain)" id="model" type="text" maxlength="200" ng-required="true" />
+            <span class="field-error" ng-show="equipmentForm.model.$error.required && showError" openlmis-message="missing.value"></span>
+          </div>
+        </div>
+
+        <div class="form-cell">
           <label for="model">
             <span openlmis-message="label.equipment.energy-type"></span>
-            <span class="label-required">*</span>
+            <span class="label-required" ng-show="equipment.designation !==undefined && equipment.designation.hasEnergy">*</span>
           </label>
           <div class="form-field">
             <select ng-model="equipment.energyTypeId" id="energy-type" ng-required="equipment.designation !==undefined && equipment.designation.hasEnergy">
@@ -95,11 +78,29 @@
             </select>
           </div>
         </div>
+
       </div>
 
     </div>
 <!--cold chain fields rows start here -->
     <div class="form-group" ng-show="equipment.equipmentType.coldChain != undefined && equipment.equipmentType.coldChain">
+
+      <div class="form-row clearfix">
+
+        <div class="form-cell" >
+          <label for="designation">
+            <span openlmis-message="label.equipment.designation"></span>
+            <span class="label-required">*</span>
+          </label>
+          <div class="form-field">
+            <select ng-model="equipment.designation" ng-options="designation as designation.name for designation in designations" id="designation" name="designation" ng-required="equipment.equipmentType.coldChain">
+              <option openlmis-message="Select"  value=""></option>
+            </select>
+            <span class="field-error" ng-show="equipmentForm.designation.$error.required && showError" openlmis-message="missing.value"></span>
+          </div>
+        </div>
+
+      </div>
 
       <!--Capacity-->
 <!--Refrigerator-->
@@ -155,7 +156,7 @@
           </div>
         </div>
 
-        <div class="form-cell">
+        <div class="form-cell" ng-show="equipment.designation !==undefined">
           <label for="pqs-code">
             <span openlmis-message="label.equipment.pqs-code"></span>
           </label>


### PR DESCRIPTION
Numerous issues with the page. PQS designation setting is required in order to save and view other fields, which does not make sense for non cold chain equipment (CCE). Put PQS designation field in CCE section and move name to its place. Make energy types only required for CC equipment.

Hide PQS code field when designation not selected, like all the other fields.

Do not set designationId on save for non CC equipment.