### PR TITLE
OLMIS-136 Fix blank PQS designation field in edit

### DIFF
--- a/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/manage/partials/create.html
+++ b/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/manage/partials/create.html
@@ -93,7 +93,7 @@
             <span class="label-required">*</span>
           </label>
           <div class="form-field">
-            <select ng-model="equipment.designation" ng-options="designation as designation.name for designation in designations" id="designation" name="designation" ng-required="equipment.equipmentType.coldChain">
+            <select ng-model="equipment.designation" ng-options="designation as designation.name for designation in designations track by designation.id" id="designation" name="designation" ng-required="equipment.equipmentType.coldChain">
               <option openlmis-message="Select"  value=""></option>
             </select>
             <span class="field-error" ng-show="equipmentForm.designation.$error.required && showError" openlmis-message="missing.value"></span>


### PR DESCRIPTION
PQS designation field is blank in the edit page because when using an object for ngModel with ngOptions, setting a preselected value will not work, because ngModel checks by reference, not by value. The solution here is to use ngOptions "track by" to track by the object's id property, rather than the object itself.