### PR TITLE
OLMIS-140 Fix saving of regimens in regimen template

### DIFF
--- a/modules/openlmis-web/src/main/webapp/public/js/regimen-template/controller/save-regimen-template-controller.js
+++ b/modules/openlmis-web/src/main/webapp/public/js/regimen-template/controller/save-regimen-template-controller.js
@@ -157,7 +157,7 @@ function SaveRegimenTemplateController($scope, program, programRegimens, regimen
     var regimenForm = {};
     var regimenListToSave = [];
 
-    $(_.flatten($scope.regimensByCategory)).each(function (index, regimen) {
+    $(_.flatten(_.values($scope.regimensByCategory))).each(function (index, regimen) {
       regimen.displayOrder = index + 1;
       regimenListToSave.push(regimen);
     });


### PR DESCRIPTION
Regimens do not save properly in the regimen template. This is because the data is not put into the proper format for the save (regimensByCategory is an object of arrays, and should be an array of arrays). Call underscore values to convert before calling underscore flatten.