### PR TITLE
Use environment variable for configuration

### DIFF
--- a/modules/core/src/main/java/org/openlmis/core/service/StaticReferenceDataService.java
+++ b/modules/core/src/main/java/org/openlmis/core/service/StaticReferenceDataService.java
@@ -20,7 +20,7 @@ import org.springframework.stereotype.Service;
  */
 
 @Service
-@PropertySource({"classpath:/default.properties", "classpath:/app.properties"})
+@PropertySource({"classpath:/default.properties", "classpath:${environmentName}/app.properties"})
 public class StaticReferenceDataService {
 
   @Autowired

--- a/modules/db/src/test/resources/test-applicationContext-db.xml
+++ b/modules/db/src/test/resources/test-applicationContext-db.xml
@@ -25,7 +25,7 @@
 
         <property name="locations">
             <list>
-                <value>classpath:config/local/postgresql.properties</value>
+                <value>classpath:config/${environmentName}/postgresql.properties</value>
             </list>
         </property>
 

--- a/modules/openlmis-web/build.gradle
+++ b/modules/openlmis-web/build.gradle
@@ -203,6 +203,7 @@ jettyRun {
     daemon = true;
     jettyRun.scanIntervalSeconds = 1
     System.properties.get('defaultLocale', 'en')
+    System.properties.get('environmentName', 'local')
 }
 
 def configureHttps(keystore, password) {

--- a/modules/openlmis-web/src/main/resources/applicationContext.xml
+++ b/modules/openlmis-web/src/main/resources/applicationContext.xml
@@ -40,7 +40,7 @@
         <property name="locations">
             <list>
                 <value>classpath:/default.properties</value>
-                <value>classpath:/app.properties</value>
+                <value>classpath:${environmentName}/app.properties</value>
                 <value>classpath:/database-config.properties</value>
             </list>
         </property>


### PR DESCRIPTION
OpenLMIS originally allowed the location of its app.properties file to be specified via an environment variable called environmentName. VillageReach's deployment scripts rely on this flexibility. For some reason, though, it was removed. This commit restores this functionality, taking care to leave reference to the database-config.properties file which isn’t part of our known configuration file set, but which may nevertheless be used on existing deployments.