### PR TITLE
OLMIS-153 Fix wrong date when updating inventory status through list page

### DIFF
--- a/modules/equipment/src/main/java/org/openlmis/equipment/domain/EquipmentInventory.java
+++ b/modules/equipment/src/main/java/org/openlmis/equipment/domain/EquipmentInventory.java
@@ -12,13 +12,16 @@
 
 package org.openlmis.equipment.domain;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.openlmis.core.domain.BaseModel;
 import org.openlmis.core.domain.Facility;
+import org.openlmis.core.serializer.DateDeserializer;
 import org.openlmis.core.utils.DateUtil;
 
 import java.util.Date;
@@ -48,16 +51,14 @@ public class EquipmentInventory extends BaseModel {
   private String nameOfAssessor;
   private Long primaryDonorId;
   private Boolean isActive;
+
+  @JsonDeserialize(using = DateDeserializer.class)
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   private Date dateDecommissioned;
+
+  @JsonDeserialize(using = DateDeserializer.class)
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   private Date dateLastAssessed;
+
   private Boolean hasStabilizer;
-
-  public String getDateLastAssessedString() {
-    return DateUtil.getFormattedDate(this.dateLastAssessed, "yyyy-MM-dd");
-  }
-
-  public String getDateDecommissionedString() {
-    return DateUtil.getFormattedDate(this.dateDecommissioned, "yyyy-MM-dd");
-  }
-
 }

--- a/modules/openlmis-web/src/main/webapp/public/js/admin/equipment/inventory/controller/create-equipment-inventory-controller.js
+++ b/modules/openlmis-web/src/main/webapp/public/js/admin/equipment/inventory/controller/create-equipment-inventory-controller.js
@@ -55,7 +55,7 @@ function CreateEquipmentInventoryController($scope, $location, $routeParams, Equ
     $scope.inventory.isActive = true;
     // To match format UI expects, need to use ISO string and split out time from date
     var now = new Date();
-    $scope.inventory.dateLastAssessedString = now.toISOString().split("T")[0];
+    $scope.inventory.dateLastAssessed = now.toISOString().split("T")[0];
     $scope.inventory.yearOfInstallation = now.getFullYear();
 
     if ($routeParams.from === "0") {
@@ -144,17 +144,6 @@ function CreateEquipmentInventoryController($scope, $location, $routeParams, Equ
 
       if (!$scope.inventory.equipment.name) {
         $scope.inventory.equipment.name = $scope.inventory.equipment.manufacturer + " / " + $scope.inventory.equipment.model;
-      }
-
-      // When saving, need to make sure date fields are set from string date fields
-      // Do this by parsing date string and add timezone offset seconds
-      var now = new Date();
-      if ($scope.inventory.dateDecommissionedString) {
-        $scope.inventory.dateDecommissioned = Date.parse($scope.inventory.dateDecommissionedString) + (now.getTimezoneOffset()*60000);
-      }
-
-      if ($scope.inventory.dateLastAssessedString) {
-        $scope.inventory.dateLastAssessed = Date.parse($scope.inventory.dateLastAssessedString) + (now.getTimezoneOffset()*60000);
       }
 
       SaveEquipmentInventory.save($scope.inventory, function (data) {

--- a/modules/openlmis-web/src/main/webapp/public/js/admin/equipment/inventory/controller/equipment-inventory-controller.js
+++ b/modules/openlmis-web/src/main/webapp/public/js/admin/equipment/inventory/controller/equipment-inventory-controller.js
@@ -147,6 +147,13 @@ function EquipmentInventoryController($scope, UserFacilityList, EquipmentInvento
   $scope.saveModal = function () {
     $scope.modalError = '';
     if (!$scope.notFunctionalForm.$invalid) {
+      // When saving, need to make sure date fields are set from string date fields
+      // Do this by parsing date string and add timezone offset seconds
+      var now = new Date();
+      if ($scope.modalItem.dateDecommissionedString) {
+        $scope.modalItem.dateDecommissioned = Date.parse($scope.modalItem.dateDecommissionedString) + (now.getTimezoneOffset()*60000);
+      }
+
       SaveEquipmentInventory.save($scope.modalItem, function () {
         // Success
         $scope.notFunctionalModal = false;

--- a/modules/openlmis-web/src/main/webapp/public/js/admin/equipment/inventory/controller/equipment-inventory-controller.js
+++ b/modules/openlmis-web/src/main/webapp/public/js/admin/equipment/inventory/controller/equipment-inventory-controller.js
@@ -147,13 +147,6 @@ function EquipmentInventoryController($scope, UserFacilityList, EquipmentInvento
   $scope.saveModal = function () {
     $scope.modalError = '';
     if (!$scope.notFunctionalForm.$invalid) {
-      // When saving, need to make sure date fields are set from string date fields
-      // Do this by parsing date string and add timezone offset seconds
-      var now = new Date();
-      if ($scope.modalItem.dateDecommissionedString) {
-        $scope.modalItem.dateDecommissioned = Date.parse($scope.modalItem.dateDecommissionedString) + (now.getTimezoneOffset()*60000);
-      }
-
       SaveEquipmentInventory.save($scope.modalItem, function () {
         // Success
         $scope.notFunctionalModal = false;

--- a/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/inventory/partials/assessment-information.html
+++ b/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/inventory/partials/assessment-information.html
@@ -26,8 +26,8 @@
         <span openlmis-message="label.equipment.date.last.assessed"></span>
       </label>
       <div class="form-field">
-        <input ng-model="inventory.dateLastAssessedString" name="dateLastAssessed" id="dateLastAssessed" ng-change="blurDateFields();" ui-date="{maxDate: 'today', dateFormat: 'dd/mm/yy', changeYear: true}" ui-date-format="yy-mm-dd" />
-        <span class="field-error" ng-show="inventoryForm.dateLastAssessedString.$error.required && showError" openlmis-message="missing.value"></span>
+        <input ng-model="inventory.dateLastAssessed" name="dateLastAssessed" id="dateLastAssessed" ng-change="blurDateFields();" ui-date="{maxDate: 'today', dateFormat: 'dd/mm/yy', changeYear: true}" ui-date-format="yy-mm-dd" />
+        <span class="field-error" ng-show="inventoryForm.dateLastAssessed.$error.required && showError" openlmis-message="missing.value"></span>
       </div>
     </div>
   </div>
@@ -45,8 +45,8 @@
         <span openlmis-message="label.equipment.date.decommissioned"></span>
       </label>
       <div class="form-field">
-        <input ng-model="inventory.dateDecommissionedString" ng-disabled="inventory.isActive" name="dateDecommissioned" ui-date="{dateFormat: 'dd/mm/yy', changeYear: true}" ui-date-format="yy-mm-dd" id="dateDecommissioned">
-        <span class="field-error" ng-show="inventoryForm.dateDecommissionedString.$error.required && showError" openlmis-message="missing.value"></span>
+        <input ng-model="inventory.dateDecommissioned" ng-disabled="inventory.isActive" name="dateDecommissioned" ui-date="{dateFormat: 'dd/mm/yy', changeYear: true}" ui-date-format="yy-mm-dd" id="dateDecommissioned">
+        <span class="field-error" ng-show="inventoryForm.dateDecommissioned.$error.required && showError" openlmis-message="missing.value"></span>
       </div>
     </div>
   </div>

--- a/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/inventory/partials/create.html
+++ b/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/inventory/partials/create.html
@@ -203,10 +203,10 @@
                 <span openlmis-message="label.equipment.date.decommissioned"></span>
               </label>
               <div class="form-field">
-                <input ng-model="inventory.dateDecommissionedString" ng-disabled="inventory.isActive"
+                <input ng-model="inventory.dateDecommissioned" ng-disabled="inventory.isActive"
                        name="dateDecommissioned" ui-date="{dateFormat: 'dd/mm/yy', changeYear: true}"
                        ui-date-format="yy-mm-dd" id="dateDecommissioned">
-                <span class="field-error" ng-show="inventoryForm.dateDecommissionedString.$error.required && showError"
+                <span class="field-error" ng-show="inventoryForm.dateDecommissioned.$error.required && showError"
                       openlmis-message="missing.value"></span>
               </div>
             </div>

--- a/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/inventory/partials/list.html
+++ b/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/inventory/partials/list.html
@@ -207,10 +207,10 @@
               <span openlmis-message="label.equipment.date.decommissioned"></span>
             </label>
             <div class="form-field">
-              <input ng-model="modalItem.dateDecommissionedString" ng-disabled="modalItem.isActive"
+              <input ng-model="modalItem.dateDecommissioned" ng-disabled="modalItem.isActive"
                      name="dateDecommissioned" ui-date="{dateFormat: 'dd/mm/yy', changeYear: true}"
                      ui-date-format="yy-mm-dd" id="dateDecommissioned">
-                <span class="field-error" ng-show="notFunctionalForm.dateDecommissionedString.$error.required && modalError"
+                <span class="field-error" ng-show="notFunctionalForm.dateDecommissioned.$error.required && modalError"
                       openlmis-message="missing.value"></span>
             </div>
           </div>

--- a/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/inventory/partials/list.html
+++ b/modules/openlmis-web/src/main/webapp/public/pages/admin/equipment/inventory/partials/list.html
@@ -207,10 +207,10 @@
               <span openlmis-message="label.equipment.date.decommissioned"></span>
             </label>
             <div class="form-field">
-              <input ng-model="modalItem.dateDecommissioned" ng-disabled="modalItem.isActive"
+              <input ng-model="modalItem.dateDecommissionedString" ng-disabled="modalItem.isActive"
                      name="dateDecommissioned" ui-date="{dateFormat: 'dd/mm/yy', changeYear: true}"
-                     ui-date-format="yy-dd-mm" id="dateDecommissioned">
-                <span class="field-error" ng-show="notFunctionalForm.dateDecommissioned.$error.required && modalError"
+                     ui-date-format="yy-mm-dd" id="dateDecommissioned">
+                <span class="field-error" ng-show="notFunctionalForm.dateDecommissionedString.$error.required && modalError"
                       openlmis-message="missing.value"></span>
             </div>
           </div>


### PR DESCRIPTION
When updating status and setting the decommissioned date, the date actually saved is incorrect. This is probably because the month and day are incorrectly transposed. Also convert from string and add a timezone offset to avoid being off by a day.