### PR TITLE
OLMIS-135 Fix visual bug in Manage POD

### DIFF
--- a/modules/openlmis-web/src/main/webapp/public/js/fulfillment/controller/pod/manage-pod-controller.js
+++ b/modules/openlmis-web/src/main/webapp/public/js/fulfillment/controller/pod/manage-pod-controller.js
@@ -27,11 +27,16 @@ function ManagePODController($scope, OrdersForManagePOD, messageService, OrderPO
         OrdersForManagePOD.get({program: $scope.filter.program}, function (data) {
           $scope.orders = data.ordersForPOD;
         });
+      } else {
+        OrdersForManagePOD.get({program: $scope.filter.program, facility: $scope.filter.facility}, function (data) {
+          $scope.orders = data.ordersForPOD;
+        });
       }
     }
   };
 
   $scope.onFacilityChanged = function(){
+    $scope.orders = [];
     OrdersForManagePOD.get({program: $scope.filter.program, facility: $scope.filter.facility}, function (data) {
       $scope.orders = data.ordersForPOD;
     });


### PR DESCRIPTION
In Manage POD page, when selecting program and facility, the list does not show properly because of a ng-grid visual glitch. Not sure what is causing it, but resetting scope.orders to an empty array before populating seems to fix it.

Also fixed another bug where deselecting the checkbox empties the order list, rather than showing the list filtered by facility.