### PR TITLE
OLMIS-147 Fix save after password reset unverifying user

### DIFF
--- a/modules/core/src/main/java/org/openlmis/core/repository/UserRepository.java
+++ b/modules/core/src/main/java/org/openlmis/core/repository/UserRepository.java
@@ -163,4 +163,8 @@ public class UserRepository {
   public List<String> getSupervisoryRights(Long userId) {
     return userMapper.getSupervisoryRights(userId);
   }
+  
+  public void verify(User user) {
+    userMapper.verify(user);
+  }
 }

--- a/modules/core/src/main/java/org/openlmis/core/repository/mapper/UserMapper.java
+++ b/modules/core/src/main/java/org/openlmis/core/repository/mapper/UserMapper.java
@@ -63,8 +63,8 @@ public interface UserMapper {
   @Update("UPDATE users SET userName = #{userName}, firstName = #{firstName}, lastName = #{lastName}, " +
     "employeeId = #{employeeId},restrictLogin = #{restrictLogin}, facilityId=#{facilityId}, jobTitle = #{jobTitle}, " +
     "primaryNotificationMethod = #{primaryNotificationMethod}, officePhone = #{officePhone}, cellPhone = #{cellPhone}, " +
-    "email = #{email}, active = #{active}, " +
-          "verified = #{verified}, ismobileuser = #{isMobileUser}, " +
+    "email = #{email}, active = #{active}, " + 
+    "ismobileuser = #{isMobileUser}, " +
     "modifiedBy = #{modifiedBy}, modifiedDate = (COALESCE(#{modifiedDate}, NOW())) WHERE id=#{id}")
   void update(User user);
 
@@ -138,4 +138,7 @@ public interface UserMapper {
     "   join role_assignments ras on ras.roleid = rr.roleId " +
     "where r.righttype = 'REQUISITION' and ras.userId = #{userId}")
   List<String> getSupervisoryRights(@Param("userId") Long userId);
+
+  @Update("UPDATE users SET verified = TRUE WHERE id = #{id}")
+  void verify(User user);
 }

--- a/modules/core/src/main/java/org/openlmis/core/service/UserService.java
+++ b/modules/core/src/main/java/org/openlmis/core/service/UserService.java
@@ -70,6 +70,9 @@ public class UserService {
     user.validate();
     userRepository.update(user);
     roleAssignmentService.saveRolesForUser(user);
+    if (user.isMobileUser()) {
+      userRepository.verify(user);
+    }
   }
 
   public LinkedHashMap getPreferences(Long userId){

--- a/modules/openlmis-web/src/main/java/org/openlmis/web/controller/UserController.java
+++ b/modules/openlmis-web/src/main/java/org/openlmis/web/controller/UserController.java
@@ -133,11 +133,6 @@ public class UserController extends BaseController {
                                                  HttpServletRequest request) {
     user.setModifiedBy(loggedInUserId(request));
     user.setId(id);
-    if (user.isMobileUser()) {
-      user.setVerified(true);
-    } else {
-      user.setIsMobileUser(false);
-    }
     try {
       userService.update(user);
     } catch (DataException e) {


### PR DESCRIPTION
Reset password code verifies unverified user; however, doing a save in the edit user screen updates the user again, and for a previously unverified user, that "Is verified" field is "No", so user is inadvertently unverified. This is because of isMobileUser code saving the verify field in the database, which was previously ignored. Re-exclude the verify field from the update method in the mapper and create a separate verify mapper method. Use that method for the isMobileUser code to automatically verify the user.