### PR TITLE
OLMIS-141 Fix program equipment product message keys not being transf…

### DIFF
--- a/modules/openlmis-web/src/main/webapp/public/js/admin/equipment/program-equipment-products/controller/program-equipment-product-list-controller.js
+++ b/modules/openlmis-web/src/main/webapp/public/js/admin/equipment/program-equipment-products/controller/program-equipment-product-list-controller.js
@@ -167,7 +167,7 @@ function ProgramEquipmentProductController($scope, $dialog, messageService, navi
       $scope.programEquipmentProduct = response.programEquipmentProduct;
       $scope.productError = false;
       $scope.productErrorMessage = '';
-      $scope.message = response.success;
+      $scope.message = messageService.get(response.success);
       $scope.showMessage = true;
       $scope.closeModal();
       $scope.refreshProgramEquipmentProductList();
@@ -241,7 +241,7 @@ function ProgramEquipmentProductController($scope, $dialog, messageService, navi
   $scope.removeProgramEquipmentProduct = function () {
 
     var successCallBack = function (response) {
-      $scope.message = response.success;
+      $scope.message = messageService.get(response.success);
       $scope.showMessage = true;
     };
 


### PR DESCRIPTION
…ormed

When adding or removing program equipment product associations, the message that is shown is a message key, not the actual message. Transform the message keys into human readable messages.