### PR TITLE
OLMIS-60 Add version number to login page

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,6 +15,11 @@ apply plugin: 'com.github.ben-manes.versions'
 apply plugin: 'properties'
 apply plugin: 'sonar-runner'
 
+ext.versionProps = new Properties()
+versionProps.load(new FileInputStream("version.properties"))
+versionProps.each { versionProp ->
+  ext.set(versionProp.key, versionProp.value)
+}
 
 idea.project.languageLevel = '1.7'
 idea.project.jdkName = '1.7'

--- a/modules/openlmis-web/build.gradle
+++ b/modules/openlmis-web/build.gradle
@@ -141,6 +141,12 @@ tasks.withType(War) {
                 else
                     "$line"
             }
+        if (fileCopy.name.equals('login-form.html')) {
+            fileCopy.filter(ReplaceTokens, tokens: [major_version: majorVersion, 
+                                                    minor_version: minorVersion, 
+                                                    hotfix_version: hotfixVersion, 
+                                                    build_version: buildVersion])
+        }
     }
 }
 

--- a/modules/openlmis-web/src/main/webapp/public/pages/login-form.html
+++ b/modules/openlmis-web/src/main/webapp/public/pages/login-form.html
@@ -41,7 +41,7 @@
         </form>
     </div>
     <div class="powered-by">
-        Powered by <a href="http://openlmis.org" target="_blank">OpenLMIS</a>
+        Powered by <a href="http://openlmis.org" target="_blank">OpenLMIS</a> v@major_version@.@minor_version@.@hotfix_version@ build @build_version@
     </div>
 </div>
 

--- a/version.properties
+++ b/version.properties
@@ -1,0 +1,4 @@
+majorVersion = 2
+minorVersion = 0
+hotfixVersion = 1
+buildVersion = Developer


### PR DESCRIPTION
During the build, edit the login page to show the version number from the version property file. Build number is either a custom developer build (the property file default) or can be passed in as a parameter.